### PR TITLE
Workaround for missing sheets in SMP forecasts table

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: readrba
 Title: Download and Tidy Data from the Reserve Bank of Australia
-Version: 0.1.8.901
+Version: 0.1.9
 Authors@R: 
     c(
     person(given = "Matt",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: readrba
 Title: Download and Tidy Data from the Reserve Bank of Australia
-Version: 0.1.9
+Version: 0.1.8.902
 Authors@R: 
     c(
     person(given = "Matt",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
-# readrba 0.1.8.9xx
+# readrba 0.1.9
 * Bug fixes
+* Fix for omitted data in May SMP forecast table
 
 # readrba 0.1.8
 * read_forecasts() / rba_forecasts() updated to work with the new SMP format

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# readrba 0.1.9
+# readrba 0.1.8.90x
 * Bug fixes
 * Fix for omitted data in May SMP forecast table
 

--- a/R/rba_forecasts.R
+++ b/R/rba_forecasts.R
@@ -171,6 +171,14 @@ scrape_rba_forecasts <- function() {
                                "source",
                                "rounding")
 
+  sheet_names_with_contents <- readxl::excel_sheets(xlsx_file)
+  sheet_names <- sheet_names_with_contents[sheet_names_with_contents != "Contents"]
+
+  missing_sheets <- xlsx_metadata$sheet_name[!xlsx_metadata$sheet_name %in% sheet_names]
+
+  warning(paste("The following worksheets are missing from the RBA forecast file: ",
+                paste(missing_sheets, collapse = ", ")))
+
   tidy_forecast_sheet <- function(sheet_name) {
     readxl::read_excel(xlsx_file,
                        sheet = sheet_name,
@@ -189,8 +197,8 @@ scrape_rba_forecasts <- function() {
   }
 
 
-  fc_without_metadata <- purrr::map_dfr(xlsx_metadata$sheet_name,
-                                            tidy_forecast_sheet)
+  fc_without_metadata <- purrr::map_dfr(sheet_names,
+                                        tidy_forecast_sheet)
 
   fc_raw <- fc_without_metadata %>%
     dplyr::left_join(xlsx_metadata, by = "sheet_name") %>%

--- a/R/tidy_rba.R
+++ b/R/tidy_rba.R
@@ -111,6 +111,11 @@ tidy_rba_normal <- function(excel_sheet, .table_title, series_id = NULL) {
 
   excel_sheet <- excel_sheet[!is.na(excel_sheet$title), ]
 
+  all_na_col <- purrr::map_lgl(excel_sheet,
+                               \(x) all(is.na(x)))
+
+  excel_sheet <- excel_sheet[!all_na_col]
+
   excel_sheet <- excel_sheet %>%
     tidyr::pivot_longer(
       cols = !"title",


### PR DESCRIPTION
See issue here: https://github.com/MattCowgill/readrba/issues/54 

This PR makes it possible to import the RBA's forecasts, even when some are missing from the published table. This does not fully 'fix' the issue, in that data that has not been published in the forecasts table is not imported.

It also separately addresses an issue that was affecting table C2.2; closes https://github.com/MattCowgill/readrba/issues/55.